### PR TITLE
Add support for PyPy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ python:
     - 2.7
     - 3.2
     - 3.3
+    - pypy
+    - pypy3
 install:
-    - pip install . --use-mirrors
+    - pip install .
 script:
     - python setup.py test -q
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 4.1.4 (unreleased)
 ------------------
 
-- TBD
+- Added support for PyPy.
 
 
 4.1.3 (2014-03-19)

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         "Framework :: Zope3",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Testing",

--- a/src/zope/testing/doctest.txt
+++ b/src/zope/testing/doctest.txt
@@ -15,7 +15,8 @@ some of the test files broken:
 
   >>> import tempfile
   >>> fn = tempfile.mktemp()
-  >>> foo = open(fn, 'w').write('Test:\r\n\r\n  >>> x = 1 + 1\r\n\r\nDone.\r\n')
+  >>> with open(fn, 'w') as f:
+  ...    _ = f.write('Test:\r\n\r\n  >>> x = 1 + 1\r\n\r\nDone.\r\n')
 
 Let's now run it as a doctest:
 
@@ -30,4 +31,3 @@ It worked. Let's also try the test file suite:
   >>> result = unittest.TestResult()
   >>> doctest.DocFileSuite(fn, module_relative=False).run(result) #doctest: +ELLIPSIS
   <...TestResult run=1 errors=0 failures=0>
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py32,py33,py34
+    py26,py27,py32,py33,py34,pypy,pypy3
 
 [testenv]
 commands =


### PR DESCRIPTION
In order to make the tests pass this needed only a minor change to a test to close a file instead of letting refcounting do it.