### PR TITLE
Add a pattern for normalizing Python 3.5 nested exception doctest output

### DIFF
--- a/src/zope/testing/tests.py
+++ b/src/zope/testing/tests.py
@@ -40,7 +40,11 @@ def test_suite():
         doctest.DocFileSuite(
             'wait.txt', setUp=setUp,
             checker=renormalizing.RENormalizing([
+                # For Python 3.4.
                 (re.compile('zope.testing.wait.TimeOutWaitingFor: '),
+                 'TimeOutWaitingFor: '),
+                # For Python 3.5
+                (re.compile('zope.testing.wait.Wait.TimeOutWaitingFor: '),
                  'TimeOutWaitingFor: '),
                 ])
             ),


### PR DESCRIPTION
Subject says it all.  With this change the suite passes for me on 2.7, 3.4, and 3.5.