### PR TITLE
Setupstack testcase

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changes
 =======
 
+- Added ``zope.testing.setupstack.mock`` as a convenience function for
+  setting up mocks in tests.  (The Python ``mock`` package must be in
+  the path for this to work. The excellent ``mock`` package isn't a
+  dependency of ``zope.testing``.)
+
+- Added the base class ``zope.testing.setupstack.TextCase`` to make it
+  much easier to use ``zope.testing.setupstack`` in ``unittest`` test
+  cases.
+
+
 4.3.0 (2015-07-15)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changes
   the path for this to work. The excellent ``mock`` package isn't a
   dependency of ``zope.testing``.)
 
-- Added the base class ``zope.testing.setupstack.TextCase`` to make it
+- Added the base class ``zope.testing.setupstack.TestCase`` to make it
   much easier to use ``zope.testing.setupstack`` in ``unittest`` test
   cases.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,12 @@
 Changes
 =======
 
+4.3.0 (2015-07-15)
+------------------
+
 - Added support for creating doctests as methods of
   ``unittest.TestCase`` classes so that they can found automatically
   by test runners, like *nose* that ignore test suites.
-
-4.2.1 (unreleased)
-------------------
-
-- TBD
 
 4.2.0 (2015-06-01)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ long_description='\n\n'.join(
 
 setup(
     name='zope.testing',
-    version='4.2.1.dev0',
+    version='4.3.0',
     url='http://pypi.python.org/pypi/zope.testing',
     license='ZPL 2.1',
     description='Zope testing helpers',

--- a/src/zope/testing/setupstack.py
+++ b/src/zope/testing/setupstack.py
@@ -16,7 +16,10 @@
 See setupstack.txt
 """
 
-import os, stat, tempfile
+import os
+import stat
+import tempfile
+import unittest
 
 key = '__' + __name__
 
@@ -64,3 +67,19 @@ def context_manager(test, manager):
     register(test, manager.__exit__, None, None, None)
     return result
 
+def mock(test, *args, **kw):
+    try:
+        mock_module
+    except NameError:
+        global mock_module
+        import mock as mock_module
+
+    return context_manager(test, mock_module.patch(*args, **kw))
+
+class TestCase(unittest.TestCase):
+
+    tearDown = tearDown
+    register = register
+    setUpDirectory = setUpDirectory
+    context_manager = context_manager
+    mock = mock

--- a/src/zope/testing/setupstack.py
+++ b/src/zope/testing/setupstack.py
@@ -68,12 +68,7 @@ def context_manager(test, manager):
     return result
 
 def mock(test, *args, **kw):
-    global mock_module
-    try:
-        mock_module
-    except NameError:
-        import mock as mock_module
-
+    import mock as mock_module
     return context_manager(test, mock_module.patch(*args, **kw))
 
 class TestCase(unittest.TestCase):

--- a/src/zope/testing/setupstack.py
+++ b/src/zope/testing/setupstack.py
@@ -68,10 +68,10 @@ def context_manager(test, manager):
     return result
 
 def mock(test, *args, **kw):
+    global mock_module
     try:
         mock_module
     except NameError:
-        global mock_module
         import mock as mock_module
 
     return context_manager(test, mock_module.patch(*args, **kw))

--- a/src/zope/testing/setupstack.txt
+++ b/src/zope/testing/setupstack.txt
@@ -245,14 +245,13 @@ Here's an example:
     >>> import unittest
     >>> loader = unittest.TestLoader()
     >>> suite = loader.loadTestsFromTestCase(MyTests)
-    >>> result = suite.run(unittest.TextTestResult(sys.stdout, True, 1))
+    >>> result = suite.run(unittest.TestResult())
     enter
     enter time.time {'return_value': 42}
     []
     done w test
     exit (None, None, None) time.time {'return_value': 42}
     exit (None, None, None)
-    .
 
 .. cleanup
 

--- a/src/zope/testing/setupstack.txt
+++ b/src/zope/testing/setupstack.txt
@@ -218,7 +218,7 @@ context_manager(manager)
 mock(*args, **kw)
     Enters  ``mock.patch`` with the given arguments.
 
-    This is syntactic sugure for::
+    This is syntactic sugur for::
 
         context_manager(mock.patch(*args, **kw))
 

--- a/src/zope/testing/setupstack.txt
+++ b/src/zope/testing/setupstack.txt
@@ -120,11 +120,15 @@ returned. The context-manager's __exit__ method will be called as part
 of test tear down:
 
     >>> class Manager(object):
+    ...     def __init__(self, *args, **kw):
+    ...         if kw:
+    ...             args += (kw, )
+    ...         self.args = args
     ...     def __enter__(self):
-    ...         print_('enter')
+    ...         print_('enter', *self.args)
     ...         return 42
     ...     def __exit__(self, *args):
-    ...         print_('exit', args)
+    ...         print_('exit', args, *self.args)
 
     >>> manager = Manager()
     >>> test = Test()
@@ -135,6 +139,26 @@ of test tear down:
 
     >>> zope.testing.setupstack.tearDown(test)
     exit (None, None, None)
+
+.. faux mock
+
+    >>> old_mock = sys.modules.get('mock')
+    >>> class FauxMock:
+    ...     @classmethod
+    ...     def patch(self, *args, **kw):
+    ...         return Manager(*args, **kw)
+
+    >>> sys.modules['mock'] = FauxMock
+
+By far the most commonly called context manager is ``mock.patch``, so
+there's a convenience function to make that simpler:
+
+    >>> zope.testing.setupstack.mock(test, 'time.time', return_value=42)
+    enter time.time {'return_value': 42}
+    42
+
+    >>> zope.testing.setupstack.tearDown(test)
+    exit (None, None, None) time.time {'return_value': 42}
 
 globs
 -----
@@ -170,3 +194,71 @@ will be used:
 
 The ``globs`` function is used internally, but can also be used by
 setup code to support either doctests or other test objects.
+
+TestCase
+--------
+
+A TestCase class is provided that:
+
+- Makes it easier to call setupstack apis, and
+
+- provides an inheritable tearDown method.
+
+In addition to a tearDown method, the class provides methods:
+
+setupDirectory()
+    Creates a temporary directory, runs the test, and cleans it up.
+
+register(func)
+    Register a tear-down function.
+
+context_manager(manager)
+    Enters a context manager and exits it on tearDown.
+
+mock(*args, **kw)
+    Enters  ``mock.patch`` with the given arguments.
+
+    This is syntactic sugure for::
+
+        context_manager(mock.patch(*args, **kw))
+
+Here's an example:
+
+    >>> open('t', 'w').close()
+
+    >>> class MyTests(zope.testing.setupstack.TestCase):
+    ...
+    ...     def setUp(self):
+    ...         self.setUpDirectory()
+    ...         self.context_manager(manager)
+    ...         self.mock("time.time", return_value=42)
+    ...
+    ...         @self.register
+    ...         def _():
+    ...             print('done w test')
+    ...
+    ...     def test(self):
+    ...         print(os.listdir('.'))
+
+.. let's try it
+
+    >>> import unittest
+    >>> loader = unittest.TestLoader()
+    >>> suite = loader.loadTestsFromTestCase(MyTests)
+    >>> result = suite.run(unittest.TextTestResult(sys.stdout, True, 1))
+    enter
+    enter time.time {'return_value': 42}
+    []
+    done w test
+    exit (None, None, None) time.time {'return_value': 42}
+    exit (None, None, None)
+    .
+
+.. cleanup
+
+    >>> if old_mock:
+    ...     sys.modules['mock'] = old_mock
+    ... else:
+    ...     del sys.modules['mock']
+    >>> os.remove('t')
+


### PR DESCRIPTION
- Added ``zope.testing.setupstack.mock`` as a convenience function for
  setting up mocks in tests.  (The Python ``mock`` package must be in
  the path for this to work. The excellent ``mock`` package isn't a
  dependency of ``zope.testing``.)

- Added the base class ``zope.testing.setupstack.TextCase`` to make it
  much easier to use ``zope.testing.setupstack`` in ``unittest`` test
  cases.
