### PR TITLE
Skip broken symlink test on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+environment:
+
+  matrix:
+    - python : 27
+    - python : 27-x64
+    - python : 33
+    - python : 33-x64
+    - python : 34
+    - python : 34-x64
+    - python : 35
+    - python : 35-x64
+
+install:
+  - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"
+  - pip install -e .
+
+build: false
+
+test_script:
+  - python setup.py -q test -q
+
+on_success:
+  - echo Build succesful!

--- a/src/zope/testing/setupstack.txt
+++ b/src/zope/testing/setupstack.txt
@@ -93,7 +93,7 @@ On Unix systems, broken symlinks can cause problems because the chmod
 attempt by the teardown hook will fail; let's set up a broken symlink as
 well, and verify the teardown doesn't break because of that:
 
-    >>> if hasattr(os, 'symlink'):
+    >>> if sys.platform != 'win32':
     ...     os.symlink('NotThere', 'BrokenLink')
 
 When tearDown is called:


### PR DESCRIPTION
Python 3.2 introduced os.symlink() on Windows platforms, but it raises
NotImplementedError if the underlying OS is too old to support symlinks
(like what we have on winbot).

Fixes #13.