### PR TITLE
Doctest 2 to 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,12 +10,13 @@ Changes
 
 - Cleaned up useless 2to3 conversion.
 
-- Introduce optionflag ``EXCEPTION_2TO3`` to normalize exception class names
-  in traceback output. In Python 3 they are displayed as the full dotted name.
-  In Python 2 they are displayed as "just" the class name.  When running
-  doctests in Python 3, the optionflag will not have any effect, however when
-  running the same test in Python 2, the segments in the full dotted name
-  leading up to the class name are stripped away from the "expected" string.
+- Introduce option flag ``IGNORE_EXCEPTION_MODULE_IN_PYTHON2`` to normalize
+  exception class names in traceback output. In Python 3 they are displayed as
+  the full dotted name. In Python 2 they are displayed as "just" the class
+  name.  When running doctests in Python 3, the option flag will not have any
+  effect, however when running the same test in Python 2, the segments in the
+  full dotted name leading up to the class name are stripped away from the
+  "expected" string.
 
 4.5.0 (2015-09-02)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ Changes
 
 - Cleaned up useless 2to3 conversion.
 
+- Introduce optionflag ``EXCEPTION_2TO3`` to normalize exception class names
+  in traceback output. In Python 3 they are displayed as the full dotted name.
+  In Python 2 they are displayed as "just" the class name.  When running
+  doctests in Python 3, the optionflag will not have any effect, however when
+  running the same test in Python 2, the segments in the full dotted name
+  leading up to the class name are stripped away from the "expected" string.
+
 4.5.0 (2015-09-02)
 ------------------
 

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -12,6 +12,7 @@
 #
 ##############################################################################
 import sys
+import re
 import doctest
 
 
@@ -96,11 +97,18 @@ class OutputChecker(doctest.OutputChecker):
 RENormalizing = OutputChecker
 
 
+_TRACEBACK_RE = re.compile(
+    r"Traceback \((most recent call last|innermost last)\):")
+
+
 def maybe_a_traceback(string):
     if not string:
         return None
 
     lines = string.splitlines()
+    if not _TRACEBACK_RE.match(lines[0]):
+        return None
+
     last = lines[-1]
     words = last.split(' ')
     first = words[0]
@@ -111,8 +119,6 @@ def maybe_a_traceback(string):
 
 
 def strip_dottedname_from_traceback(string):
-    # We might want to confirm more strictly were dealing with a traceback.
-    # We'll assume so for now.
     maybe = maybe_a_traceback(string)
     if maybe is None:
         return string

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -12,7 +12,6 @@
 #
 ##############################################################################
 import sys
-import re
 import doctest
 
 
@@ -99,18 +98,15 @@ class OutputChecker(doctest.OutputChecker):
 RENormalizing = OutputChecker
 
 
-_TRACEBACK_RE = re.compile(
-    r"Traceback \((most recent call last|innermost last)\):")
-
-
 def maybe_a_traceback(string):
+    # We wanted to confirm more strictly we're dealing with a traceback here.
+    # However, doctest will preprocess exception output. It gets rid of the
+    # the stack trace and the "Traceback (most recent call last)"-part. It
+    # passes only the exception message to the checker.
     if not string:
         return None
 
     lines = string.splitlines()
-    if not _TRACEBACK_RE.match(lines[0]):
-        return None
-
     last = lines[-1]
     words = last.split(' ')
     first = words[0]

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -15,12 +15,13 @@ import sys
 import doctest
 
 
-EXCEPTION_2TO3 = doctest.register_optionflag('EXCEPTION_2TO3')
-EXCEPTION_2TO3_HINT = """\
+IGNORE_EXCEPTION_MODULE_IN_PYTHON2 = doctest.register_optionflag(
+    'IGNORE_EXCEPTION_MODULE_IN_PYTHON2')
+IGNORE_EXCEPTION_MODULE_IN_PYTHON2_HINT = """\
 ===============================================================
 HINT:
   You seem to test traceback output.
-  The optionflag EXCEPTION_2TO3 is set.
+  The optionflag IGNORE_EXCEPTION_MODULE_IN_PYTHON2 is set.
   Do you use the full dotted name for the exception class name?
 ==============================================================="""
 
@@ -54,7 +55,7 @@ class OutputChecker(doctest.OutputChecker):
             got = transformer(got)
 
         if sys.version_info[0] < 3:
-            if optionflags & EXCEPTION_2TO3:
+            if optionflags & IGNORE_EXCEPTION_MODULE_IN_PYTHON2:
                 want = strip_dottedname_from_traceback(want)
 
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
@@ -82,9 +83,9 @@ class OutputChecker(doctest.OutputChecker):
         example.want = want
 
         if sys.version_info[0] < 3:
-            if optionflags & EXCEPTION_2TO3:
+            if optionflags & IGNORE_EXCEPTION_MODULE_IN_PYTHON2:
                 if maybe_a_traceback(got) is not None:
-                    got += EXCEPTION_2TO3_HINT
+                    got += IGNORE_EXCEPTION_MODULE_IN_PYTHON2_HINT
 
         result = doctest.OutputChecker.output_difference(
             self, example, got, optionflags)

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -53,7 +53,7 @@ class OutputChecker(doctest.OutputChecker):
             want = transformer(want)
             got = transformer(got)
 
-        if sys.version < '3':
+        if sys.version_info[0] < 3:
             if optionflags & EXCEPTION_2TO3:
                 want = strip_dottedname_from_traceback(want)
 
@@ -81,7 +81,7 @@ class OutputChecker(doctest.OutputChecker):
         # temporarily hack example with normalized want:
         example.want = want
 
-        if sys.version < '3':
+        if sys.version_info[0] < 3:
             if optionflags & EXCEPTION_2TO3:
                 if maybe_a_traceback(got) is not None:
                     got += EXCEPTION_2TO3_HINT

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -16,7 +16,7 @@ import doctest
 
 
 EXCEPTION_2TO3 = doctest.register_optionflag('EXCEPTION_2TO3')
-EXCEPTION_2TO3_HINT = """
+EXCEPTION_2TO3_HINT = """\
 ===============================================================
 HINT:
   You seem to test traceback output.

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -21,9 +21,11 @@ IGNORE_EXCEPTION_MODULE_IN_PYTHON2 = doctest.register_optionflag(
 IGNORE_EXCEPTION_MODULE_IN_PYTHON2_HINT = """\
 ===============================================================
 HINT:
-  You seem to test traceback output.
   The optionflag IGNORE_EXCEPTION_MODULE_IN_PYTHON2 is set.
-  Do you use the full dotted name for the exception class name?
+  You seem to test traceback output.
+  If you are indeed, make sure to use the full dotted name of
+  the exception class like Python 3 displays,
+  even though you are running the tests in Python 2.
 ==============================================================="""
 
 

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -25,6 +25,8 @@ HINT:
   If you are indeed, make sure to use the full dotted name of
   the exception class like Python 3 displays,
   even though you are running the tests in Python 2.
+  The exception message needs to be last line (and thus not
+  split over multiple lines).
 ==============================================================="""
 
 

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -29,7 +29,9 @@ class OutputChecker(doctest.OutputChecker):
     """Pattern-normalizing outout checker
     """
 
-    def __init__(self, patterns):
+    def __init__(self, patterns=None):
+        if patterns is None:
+            patterns = []
         self.transformers = list(map(self._cook, patterns))
 
     def __add__(self, other):

--- a/src/zope/testing/renormalizing.txt
+++ b/src/zope/testing/renormalizing.txt
@@ -252,3 +252,38 @@ Using the 2to3 exception normalization:
     ...     expected = False
     >>> result == expected
     True
+
+When reporting a failing test and running in Python 2, the normalizer tries
+to be helpful by explaining how to test for exceptions in the traceback output.
+
+    >>> want = """\
+    ... Traceback (most recent call last):
+    ... foo.bar.FooBarErrorXX: requires at least one argument."""
+    >>> got = """\
+    ... Traceback (most recent call last):
+    ... FooBarError: requires at least one argument."""
+    >>> checker.check_output(want, got, EXCEPTION_2TO3)
+    False
+    >>> from doctest import Example
+    >>> example = Example('dummy', want)
+    >>> result = checker.output_difference(example, got, EXCEPTION_2TO3)
+    >>> output = """\
+    ... Expected:
+    ...     Traceback (most recent call last):
+    ...     foo.bar.FooBarErrorXX: requires at least one argument.
+    ... Got:
+    ...     Traceback (most recent call last):
+    ...     FooBarError: requires at least one argument."""
+    >>> hint = """
+    ...     ===============================================================
+    ...     HINT:
+    ...       You seem to test traceback output.
+    ...       The optionflag EXCEPTION_2TO3 is set.
+    ...       Do you use the full dotted name for the exception class name?
+    ...     ==============================================================="""
+    >>> if sys.version < '3':
+    ...     expected = output + hint
+    ... else:
+    ...     expected = output
+    >>> result == expected
+    True

--- a/src/zope/testing/renormalizing.txt
+++ b/src/zope/testing/renormalizing.txt
@@ -258,10 +258,12 @@ to be helpful by explaining how to test for exceptions in the traceback output.
 
     >>> want = """\
     ... Traceback (most recent call last):
-    ... foo.bar.FooBarErrorXX: requires at least one argument."""
+    ... foo.bar.FooBarErrorXX: requires at least one argument.
+    ... """
     >>> got = """\
     ... Traceback (most recent call last):
-    ... FooBarError: requires at least one argument."""
+    ... FooBarError: requires at least one argument.
+    ... """
     >>> checker.check_output(want, got, EXCEPTION_2TO3)
     False
     >>> from doctest import Example
@@ -273,8 +275,9 @@ to be helpful by explaining how to test for exceptions in the traceback output.
     ...     foo.bar.FooBarErrorXX: requires at least one argument.
     ... Got:
     ...     Traceback (most recent call last):
-    ...     FooBarError: requires at least one argument."""
-    >>> hint = """
+    ...     FooBarError: requires at least one argument.
+    ... """
+    >>> hint = """\
     ...     ===============================================================
     ...     HINT:
     ...       You seem to test traceback output.

--- a/src/zope/testing/renormalizing.txt
+++ b/src/zope/testing/renormalizing.txt
@@ -283,9 +283,11 @@ to be helpful by explaining how to test for exceptions in the traceback output.
     >>> hint = """\
     ...     ===============================================================
     ...     HINT:
-    ...       You seem to test traceback output.
     ...       The optionflag IGNORE_EXCEPTION_MODULE_IN_PYTHON2 is set.
-    ...       Do you use the full dotted name for the exception class name?
+    ...       You seem to test traceback output.
+    ...       If you are indeed, make sure to use the full dotted name of
+    ...       the exception class like Python 3 displays,
+    ...       even though you are running the tests in Python 2.
     ...     ==============================================================="""
     >>> if sys.version_info[0] < 3:
     ...     expected = output + hint

--- a/src/zope/testing/renormalizing.txt
+++ b/src/zope/testing/renormalizing.txt
@@ -246,7 +246,7 @@ Using the 2to3 exception normalization:
     ... FooBarError: requires at least one argument."""
     >>> result = checker.check_output(want, got, EXCEPTION_2TO3)
     >>> import sys
-    >>> if sys.version < '3':
+    >>> if sys.version_info[0] < 3:
     ...     expected = True
     ... else:
     ...     expected = False
@@ -284,7 +284,7 @@ to be helpful by explaining how to test for exceptions in the traceback output.
     ...       The optionflag EXCEPTION_2TO3 is set.
     ...       Do you use the full dotted name for the exception class name?
     ...     ==============================================================="""
-    >>> if sys.version < '3':
+    >>> if sys.version_info[0] < 3:
     ...     expected = output + hint
     ... else:
     ...     expected = output

--- a/src/zope/testing/renormalizing.txt
+++ b/src/zope/testing/renormalizing.txt
@@ -234,3 +234,21 @@ Combining a checker with something else does not work:
         ...
     TypeError: unsupported operand type(s) for +: ...
 
+Using the 2to3 exception normalization:
+
+    >>> from zope.testing.renormalizing import EXCEPTION_2TO3
+    >>> checker = OutputChecker(patterns=[])
+    >>> want = """\
+    ... Traceback (most recent call last):
+    ... foo.bar.FooBarError: requires at least one argument."""
+    >>> got = """\
+    ... Traceback (most recent call last):
+    ... FooBarError: requires at least one argument."""
+    >>> result = checker.check_output(want, got, EXCEPTION_2TO3)
+    >>> import sys
+    >>> if sys.version < '3':
+    ...     expected = True
+    ... else:
+    ...     expected = False
+    >>> result == expected
+    True

--- a/src/zope/testing/renormalizing.txt
+++ b/src/zope/testing/renormalizing.txt
@@ -237,7 +237,7 @@ Combining a checker with something else does not work:
 Using the 2to3 exception normalization:
 
     >>> from zope.testing.renormalizing import EXCEPTION_2TO3
-    >>> checker = OutputChecker(patterns=[])
+    >>> checker = OutputChecker()
     >>> want = """\
     ... Traceback (most recent call last):
     ... foo.bar.FooBarError: requires at least one argument."""

--- a/src/zope/testing/renormalizing.txt
+++ b/src/zope/testing/renormalizing.txt
@@ -288,6 +288,8 @@ to be helpful by explaining how to test for exceptions in the traceback output.
     ...       If you are indeed, make sure to use the full dotted name of
     ...       the exception class like Python 3 displays,
     ...       even though you are running the tests in Python 2.
+    ...       The exception message needs to be last line (and thus not
+    ...       split over multiple lines).
     ...     ==============================================================="""
     >>> if sys.version_info[0] < 3:
     ...     expected = output + hint

--- a/src/zope/testing/renormalizing.txt
+++ b/src/zope/testing/renormalizing.txt
@@ -236,7 +236,8 @@ Combining a checker with something else does not work:
 
 Using the 2to3 exception normalization:
 
-    >>> from zope.testing.renormalizing import EXCEPTION_2TO3
+    >>> from zope.testing.renormalizing import (
+    ...     IGNORE_EXCEPTION_MODULE_IN_PYTHON2)
     >>> checker = OutputChecker()
     >>> want = """\
     ... Traceback (most recent call last):
@@ -244,7 +245,8 @@ Using the 2to3 exception normalization:
     >>> got = """\
     ... Traceback (most recent call last):
     ... FooBarError: requires at least one argument."""
-    >>> result = checker.check_output(want, got, EXCEPTION_2TO3)
+    >>> result = checker.check_output(
+    ...     want, got, IGNORE_EXCEPTION_MODULE_IN_PYTHON2)
     >>> import sys
     >>> if sys.version_info[0] < 3:
     ...     expected = True
@@ -264,11 +266,12 @@ to be helpful by explaining how to test for exceptions in the traceback output.
     ... Traceback (most recent call last):
     ... FooBarError: requires at least one argument.
     ... """
-    >>> checker.check_output(want, got, EXCEPTION_2TO3)
+    >>> checker.check_output(want, got, IGNORE_EXCEPTION_MODULE_IN_PYTHON2)
     False
     >>> from doctest import Example
     >>> example = Example('dummy', want)
-    >>> result = checker.output_difference(example, got, EXCEPTION_2TO3)
+    >>> result = checker.output_difference(
+    ...     example, got, IGNORE_EXCEPTION_MODULE_IN_PYTHON2)
     >>> output = """\
     ... Expected:
     ...     Traceback (most recent call last):
@@ -281,7 +284,7 @@ to be helpful by explaining how to test for exceptions in the traceback output.
     ...     ===============================================================
     ...     HINT:
     ...       You seem to test traceback output.
-    ...       The optionflag EXCEPTION_2TO3 is set.
+    ...       The optionflag IGNORE_EXCEPTION_MODULE_IN_PYTHON2 is set.
     ...       Do you use the full dotted name for the exception class name?
     ...     ==============================================================="""
     >>> if sys.version_info[0] < 3:

--- a/src/zope/testing/test_renormalizing.py
+++ b/src/zope/testing/test_renormalizing.py
@@ -1,0 +1,54 @@
+import unittest
+
+from zope.testing.renormalizing import strip_dottedname_from_traceback
+
+
+class Exception2To3(unittest.TestCase):
+
+    def test_strip_dottedname(self):
+        string = """\
+Traceback (most recent call last):
+foo.bar.FooBarError: requires at least one argument."""
+        expected = """\
+Traceback (most recent call last):
+FooBarError: requires at least one argument."""
+        self.assertEqual(expected, strip_dottedname_from_traceback(string))
+
+    def test_no_dots_in_name(self):
+        string = """\
+Traceback (most recent call last):
+FooBarError: requires at least one argument."""
+        expected = """\
+Traceback (most recent call last):
+FooBarError: requires at least one argument."""
+        self.assertEqual(expected, strip_dottedname_from_traceback(string))
+
+    def test_no_colon_in_first_word(self):
+        string = """\
+Traceback (most recent call last):
+foo.bar.FooBarError requires at least one argument."""
+        expected = """\
+Traceback (most recent call last):
+foo.bar.FooBarError requires at least one argument."""
+        self.assertEqual(expected, strip_dottedname_from_traceback(string))
+
+    def test_input_empty(self):
+        string = ''
+        expected = ''
+        self.assertEqual(expected, strip_dottedname_from_traceback(string))
+
+    def test_input_spaces(self):
+        string = '   '
+        expected = '   '
+        self.assertEqual(expected, strip_dottedname_from_traceback(string))
+
+    def test_last_line_empty(self):
+        string = """\
+Traceback (most recent call last):
+
+"""
+        expected = """\
+Traceback (most recent call last):
+
+"""
+        self.assertEqual(expected, strip_dottedname_from_traceback(string))

--- a/src/zope/testing/test_renormalizing.py
+++ b/src/zope/testing/test_renormalizing.py
@@ -6,36 +6,30 @@ from zope.testing.renormalizing import strip_dottedname_from_traceback
 class Exception2To3(unittest.TestCase):
 
     def test_strip_dottedname(self):
-        string = """\
-        Traceback (most recent call last):
-        foo.bar.FooBarError: requires at least one argument."""
-        string = textwrap.dedent(string)
-        expected = """\
-        Traceback (most recent call last):
-        FooBarError: requires at least one argument."""
-        expected = textwrap.dedent(expected)
+        string = textwrap.dedent("""\
+            Traceback (most recent call last):
+            foo.bar.FooBarError: requires at least one argument.""")
+        expected = textwrap.dedent("""\
+            Traceback (most recent call last):
+            FooBarError: requires at least one argument.""")
         self.assertEqual(expected, strip_dottedname_from_traceback(string))
 
     def test_no_dots_in_name(self):
-        string = """\
-        Traceback (most recent call last):
-        FooBarError: requires at least one argument."""
-        string = textwrap.dedent(string)
-        expected = """\
-        Traceback (most recent call last):
-        FooBarError: requires at least one argument."""
-        expected = textwrap.dedent(expected)
+        string = textwrap.dedent("""\
+            Traceback (most recent call last):
+            FooBarError: requires at least one argument.""")
+        expected = textwrap.dedent("""\
+            Traceback (most recent call last):
+            FooBarError: requires at least one argument.""")
         self.assertEqual(expected, strip_dottedname_from_traceback(string))
 
     def test_no_colon_in_first_word(self):
-        string = """\
-        Traceback (most recent call last):
-        foo.bar.FooBarError requires at least one argument."""
-        string = textwrap.dedent(string)
-        expected = """\
-        Traceback (most recent call last):
-        foo.bar.FooBarError requires at least one argument."""
-        expected = textwrap.dedent(expected)
+        string = textwrap.dedent("""\
+            Traceback (most recent call last):
+            foo.bar.FooBarError requires at least one argument.""")
+        expected = textwrap.dedent("""\
+            Traceback (most recent call last):
+            foo.bar.FooBarError requires at least one argument.""")
         self.assertEqual(expected, strip_dottedname_from_traceback(string))
 
     def test_input_empty(self):
@@ -49,14 +43,12 @@ class Exception2To3(unittest.TestCase):
         self.assertEqual(expected, strip_dottedname_from_traceback(string))
 
     def test_last_line_empty(self):
-        string = """\
-        Traceback (most recent call last):
+        string = textwrap.dedent("""\
+            Traceback (most recent call last):
 
-        """
-        string = textwrap.dedent(string)
-        expected = """\
-        Traceback (most recent call last):
+            """)
+        expected = textwrap.dedent("""\
+            Traceback (most recent call last):
 
-        """
-        expected = textwrap.dedent(expected)
+            """)
         self.assertEqual(expected, strip_dottedname_from_traceback(string))

--- a/src/zope/testing/test_renormalizing.py
+++ b/src/zope/testing/test_renormalizing.py
@@ -1,5 +1,5 @@
 import unittest
-
+import textwrap
 from zope.testing.renormalizing import strip_dottedname_from_traceback
 
 
@@ -7,29 +7,35 @@ class Exception2To3(unittest.TestCase):
 
     def test_strip_dottedname(self):
         string = """\
-Traceback (most recent call last):
-foo.bar.FooBarError: requires at least one argument."""
+        Traceback (most recent call last):
+        foo.bar.FooBarError: requires at least one argument."""
+        string = textwrap.dedent(string)
         expected = """\
-Traceback (most recent call last):
-FooBarError: requires at least one argument."""
+        Traceback (most recent call last):
+        FooBarError: requires at least one argument."""
+        expected = textwrap.dedent(expected)
         self.assertEqual(expected, strip_dottedname_from_traceback(string))
 
     def test_no_dots_in_name(self):
         string = """\
-Traceback (most recent call last):
-FooBarError: requires at least one argument."""
+        Traceback (most recent call last):
+        FooBarError: requires at least one argument."""
+        string = textwrap.dedent(string)
         expected = """\
-Traceback (most recent call last):
-FooBarError: requires at least one argument."""
+        Traceback (most recent call last):
+        FooBarError: requires at least one argument."""
+        expected = textwrap.dedent(expected)
         self.assertEqual(expected, strip_dottedname_from_traceback(string))
 
     def test_no_colon_in_first_word(self):
         string = """\
-Traceback (most recent call last):
-foo.bar.FooBarError requires at least one argument."""
+        Traceback (most recent call last):
+        foo.bar.FooBarError requires at least one argument."""
+        string = textwrap.dedent(string)
         expected = """\
-Traceback (most recent call last):
-foo.bar.FooBarError requires at least one argument."""
+        Traceback (most recent call last):
+        foo.bar.FooBarError requires at least one argument."""
+        expected = textwrap.dedent(expected)
         self.assertEqual(expected, strip_dottedname_from_traceback(string))
 
     def test_input_empty(self):
@@ -44,11 +50,13 @@ foo.bar.FooBarError requires at least one argument."""
 
     def test_last_line_empty(self):
         string = """\
-Traceback (most recent call last):
+        Traceback (most recent call last):
 
-"""
+        """
+        string = textwrap.dedent(string)
         expected = """\
-Traceback (most recent call last):
+        Traceback (most recent call last):
 
-"""
+        """
+        expected = textwrap.dedent(expected)
         self.assertEqual(expected, strip_dottedname_from_traceback(string))

--- a/src/zope/testing/tests.py
+++ b/src/zope/testing/tests.py
@@ -55,7 +55,7 @@ def test_suite():
 
     if sys.version_info[:2] >= (2, 7):
         suite.addTests(doctest.DocFileSuite('doctestcase.txt'))
-    if sys.version < '3':
+    if sys.version_info[0] < 3:
         suite.addTests(doctest.DocTestSuite('zope.testing.server'))
         suite.addTests(doctest.DocFileSuite('formparser.txt'))
     suite.addTest(

--- a/src/zope/testing/tests.py
+++ b/src/zope/testing/tests.py
@@ -16,6 +16,7 @@ import sys
 import re
 import unittest
 from zope.testing import renormalizing
+from zope.testing.test_renormalizing import Exception2To3
 
 def print_(*args):
     sys.stdout.write(' '.join(map(str, args))+'\n')
@@ -57,4 +58,6 @@ def test_suite():
     if sys.version < '3':
         suite.addTests(doctest.DocTestSuite('zope.testing.server'))
         suite.addTests(doctest.DocFileSuite('formparser.txt'))
+    suite.addTest(
+        unittest.makeSuite(Exception2To3))
     return suite


### PR DESCRIPTION
Introduce optionflag ``EXCEPTION_2TO3`` to normalize exception class names in traceback output. In Python 3 they are displayed as the full dotted name. In Python 2 they are displayed as "just" the class name.  When running doctests in Python 3, the optionflag will not have any effect, however when running the same test in Python 2, the segments in the full dotted name leading up to the class name are stripped away from the "expected" string.