### PR TITLE
Remove deps on zope.interface and zope.exceptions. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - pypy
     - pypy3
 install:
-    - pip install .
+    - pip install -e .[test]
 script:
     - python setup.py -q test -q
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove dependencies on ``zope.interface`` and ``zope.exceptions``;
+  they're not used here.
 
 
 4.6.1 (2017-01-04)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ if platform.python_implementation() == 'PyPy' \
             'src/zope/testing/doctest.txt',
             'src/zope/testing/formparser.txt',
             'src/zope/testing/module.txt',
-            'src/zope/testing/setupstack.txt'],
+            'src/zope/testing/setupstack.txt',
+        ],
     )
 else:
     extras = {}
@@ -51,7 +52,8 @@ chapters = [
         'setupstack.txt',
         'wait.txt',
         'doctestcase.txt',
-    ]]
+    ]
+]
 
 
 long_description = '\n\n'.join(
@@ -92,13 +94,17 @@ setup(
     keywords=keywords,
     packages=[
         "zope",
-        "zope.testing"],
+        "zope.testing",
+    ],
     package_dir={'': 'src'},
     namespace_packages=['zope'],
     install_requires=[
         'setuptools',
-        'zope.exceptions',
-        'zope.interface'],
+    ],
+    extras_require={
+        'test': [
+        ],
+    },
     include_package_data=True,
     zip_safe=False,
     test_suite='zope.testing.tests.test_suite',

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,4 @@ envlist =
 commands =
     python setup.py -q test -q
 deps =
-    zope.exceptions
-    zope.interface
+    .[test]


### PR DESCRIPTION
They aren't used here and this helps prevent circular build issues.

Specifically, I'd like to (optionally!) be able to use zope.testing in zope.interface without worrying about any circular dependencies cropping up.