### PR TITLE
Build with latest available PyPy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - pypy
     - pypy3
 install:
-    - pip install .
+    - pip install -e .[test]
 script:
     - python setup.py -q test -q
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - pypy
-    - pypy3
+    - pypy-5.6.0
+    - pypy3.3-5.5-alpha
 install:
     - pip install -e .[test]
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove dependencies on ``zope.interface`` and ``zope.exceptions``;
+  they're not used here.
 
 
 4.6.1 (2017-01-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changes
 - Remove dependencies on ``zope.interface`` and ``zope.exceptions``;
   they're not used here.
 
+- Remove use of 2to3 for outdated versions of PyPy3, letting us build
+  universal wheels.
+
 
 4.6.1 (2017-01-04)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ if platform.python_implementation() == 'PyPy' \
             'src/zope/testing/doctest.txt',
             'src/zope/testing/formparser.txt',
             'src/zope/testing/module.txt',
-            'src/zope/testing/setupstack.txt'],
+            'src/zope/testing/setupstack.txt',
+        ],
     )
 else:
     extras = {}
@@ -51,7 +52,8 @@ chapters = [
         'setupstack.txt',
         'wait.txt',
         'doctestcase.txt',
-    ]]
+    ]
+]
 
 
 long_description = '\n\n'.join(
@@ -92,13 +94,17 @@ setup(
     keywords=keywords,
     packages=[
         "zope",
-        "zope.testing"],
+        "zope.testing",
+    ],
     package_dir={'': 'src'},
     namespace_packages=['zope'],
     install_requires=[
         'setuptools',
-        'zope.exceptions',
-        'zope.interface'],
+    ],
+    extras_require={
+        'test': [
+        ],
+    },
     include_package_data=True,
     zip_safe=False,
     test_suite='zope.testing.tests.test_suite',

--- a/setup.py
+++ b/setup.py
@@ -19,23 +19,7 @@
 """Setup for zope.testing package
 """
 import os
-import platform
 from setuptools import setup
-
-
-if platform.python_implementation() == 'PyPy' \
-        and platform.python_version() > '3':
-    extras = dict(
-        use_2to3=True,
-        convert_2to3_doctests=[
-            'src/zope/testing/doctest.txt',
-            'src/zope/testing/formparser.txt',
-            'src/zope/testing/module.txt',
-            'src/zope/testing/setupstack.txt',
-        ],
-    )
-else:
-    extras = {}
 
 
 def read(*rnames):
@@ -108,5 +92,4 @@ setup(
     include_package_data=True,
     zip_safe=False,
     test_suite='zope.testing.tests.test_suite',
-    **extras
 )

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,4 @@ envlist =
 commands =
     python setup.py -q test -q
 deps =
-    zope.exceptions
-    zope.interface
+    .[test]


### PR DESCRIPTION
The default version is ancient and unsupported; even this updated version is old and unsupported but it's the newest we can get so far.

This lets us avoid 2to3 on PyPy3 and claim to be a universal wheel.