### PR TITLE
Renormalize exceptions without arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changes
 
 - Drop support for Python 3.3, 3.4, and 3.5.
 
+- Extend IGNORE_EXCEPTION_MODULE_IN_PYTHON2 to cover also exceptions without
+  arguments (thus without a colon on the last line of the traceback output).
+
 
 4.7 (2018-10-04)
 ----------------

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -110,9 +110,11 @@ def maybe_a_traceback(string):
 
     lines = string.splitlines()
     last = lines[-1]
+    if not last:
+        return None
     words = last.split(' ')
     first = words[0]
-    if not first.endswith(':'):
+    if len(words) > 1 and not first.endswith(':'):
         return None
 
     return lines, last, words, first

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -11,8 +11,9 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-import sys
 import doctest
+import re
+import sys
 
 
 IGNORE_EXCEPTION_MODULE_IN_PYTHON2 = doctest.register_optionflag(
@@ -58,11 +59,17 @@ class OutputChecker(doctest.OutputChecker):
             want = transformer(want)
             got = transformer(got)
 
+        if doctest.OutputChecker.check_output(self, want, got, optionflags):
+            return True
+
         if sys.version_info[0] < 3:
             if optionflags & IGNORE_EXCEPTION_MODULE_IN_PYTHON2:
                 want = strip_dottedname_from_traceback(want)
+                if doctest.OutputChecker.check_output(
+                        self, want, got, optionflags):
+                    return True
 
-        return doctest.OutputChecker.check_output(self, want, got, optionflags)
+        return False
 
     def output_difference(self, example, got, optionflags):
 
@@ -100,6 +107,19 @@ class OutputChecker(doctest.OutputChecker):
 RENormalizing = OutputChecker
 
 
+def is_dotted_name(name):
+    if sys.version_info[0] >= 3:
+        return (
+            name and
+            all(element.isidentifier() for element in name.split('.')))
+    else:
+        # Python 2 lacked str.isidentifier, but also restricted identifiers
+        # to ASCII so a regex match is straightforward.
+        match = re.match(
+            r'^(?:[A-Za-z_][A-Za-z0-9_]*\.)*[A-Za-z_][A-Za-z0-9_]*$', name)
+        return match is not None
+
+
 def maybe_a_traceback(string):
     # We wanted to confirm more strictly we're dealing with a traceback here.
     # However, doctest will preprocess exception output. It gets rid of the
@@ -115,6 +135,15 @@ def maybe_a_traceback(string):
     words = last.split(' ')
     first = words[0]
     if len(words) > 1 and not first.endswith(':'):
+        return None
+    # If IGNORE_EXCEPTION_MODULE_IN_PYTHON2 was applied to an entire file,
+    # then this may run on strings that aren't the exception message part of
+    # a traceback.  The doctest interface makes it impossible to detect this
+    # reasonably, so do our best to restrict this to only lines that start
+    # with something that looks like a Python dotted name.  It's best to
+    # apply IGNORE_EXCEPTION_MODULE_IN_PYTHON2 only to examples that need
+    # it.
+    if not is_dotted_name(first[:-1]):
         return None
 
     return lines, last, words, first

--- a/src/zope/testing/test_renormalizing.py
+++ b/src/zope/testing/test_renormalizing.py
@@ -14,6 +14,15 @@ class Exception2To3(unittest.TestCase):
             FooBarError: requires at least one argument.""")
         self.assertEqual(expected, strip_dottedname_from_traceback(string))
 
+    def test_strip_dottedname_without_exception_arguments(self):
+        string = textwrap.dedent("""\
+            Traceback (most recent call last):
+            foo.bar.FooBarError""")
+        expected = textwrap.dedent("""\
+            Traceback (most recent call last):
+            FooBarError""")
+        self.assertEqual(expected, strip_dottedname_from_traceback(string))
+
     def test_no_dots_in_name(self):
         string = textwrap.dedent("""\
             Traceback (most recent call last):


### PR DESCRIPTION
When porting code from Python 2, it's sometimes necessary to handle
doctests with expected output like this:

    Traceback (most recent call last):
    ...
    SomeException

This happens when raising an exception with no arguments; there are a
few cases like this in Launchpad.  We can support this by making
`maybe_a_traceback` slightly more liberal.