### PR TITLE
Make setupstack.txt work again if cwd is empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changes
 =======
 
-4.9 (unreleased)
+4.8.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Make ``setupstack.txt`` test work again if the current directory is empty.
 
 
 4.8 (2021-01-04)

--- a/src/zope/testing/setupstack.txt
+++ b/src/zope/testing/setupstack.txt
@@ -224,8 +224,6 @@ In addition to a tearDown method, the class provides methods:
 
 Here's an example:
 
-    >>> curdir = os.getcwd()
-
     >>> class MyTests(zope.testing.setupstack.TestCase):
     ...
     ...     def setUp(self):
@@ -238,7 +236,7 @@ Here's an example:
     ...             print('done w test')
     ...
     ...     def test(self):
-    ...         if os.getcwd() == curdir:
+    ...         if here == os.getcwd():
     ...             print('Failed to change directory')
     ...         print(os.listdir('.'))
 

--- a/src/zope/testing/setupstack.txt
+++ b/src/zope/testing/setupstack.txt
@@ -224,8 +224,7 @@ In addition to a tearDown method, the class provides methods:
 
 Here's an example:
 
-    >>> os.listdir('.') != []
-    True
+    >>> curdir = os.getcwd()
 
     >>> class MyTests(zope.testing.setupstack.TestCase):
     ...
@@ -239,6 +238,8 @@ Here's an example:
     ...             print('done w test')
     ...
     ...     def test(self):
+    ...         if os.getcwd() == curdir:
+    ...             print('Failed to change directory')
     ...         print(os.listdir('.'))
 
 .. let's try it

--- a/src/zope/testing/setupstack.txt
+++ b/src/zope/testing/setupstack.txt
@@ -238,7 +238,6 @@ Here's an example:
     ...     def test(self):
     ...         if here == os.getcwd():
     ...             print('Failed to change directory')
-    ...         print(os.listdir('.'))
 
 .. let's try it
 
@@ -248,7 +247,6 @@ Here's an example:
     >>> result = suite.run(unittest.TestResult())
     enter
     enter time.time {'return_value': 42}
-    []
     done w test
     exit (None, None, None) time.time {'return_value': 42}
     exit (None, None, None)


### PR DESCRIPTION
z3c.recipe.compattest apparently runs tests with an empty current
directory, so we need a slightly different approach to prove that
setUpDirectory actually changes directory.  (Regressed in 4.8.)

Noticed due to https://github.com/zopefoundation/zopetoolkit/pull/50.