### PR TITLE
Improve test coverage

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -13,7 +13,7 @@ with-sphinx-doctests = false
 with-windows = true
 
 [coverage]
-fail-under = 55
+fail-under = 99
 
 [tox]
 use-flake8 = true
@@ -21,4 +21,14 @@ use-flake8 = true
 [manifest]
 additional-rules = [
     "recursive-include src *.txt",
+    ]
+
+[coverage-run]
+additional-config = [
+    "# omit files which just contain BBB code or are not Python 3 compatible:",
+    "omit =",
+    "    src/zope/testing/exceptions.py",
+    "    src/zope/testing/formparser.py",
+    "    src/zope/testing/loghandler.py",
+    "    src/zope/testing/testrunner.py",
     ]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Improve test coverage show deprecation warnings when importing modules which
+  are not ported to Python 3.
 
 
 4.9 (2021-01-08)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changes
 4.10 (unreleased)
 -----------------
 
-- Improve test coverage show deprecation warnings when importing modules which
-  are not ported to Python 3.
+- Show deprecation warnings when importing modules which are not ported to
+  Python 3.
+
+- Improve test coverage.
 
 
 4.9 (2021-01-08)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/zope/testing/cleanup.txt
+++ b/src/zope/testing/cleanup.txt
@@ -1,0 +1,27 @@
+==================
+ Cleanup registry
+==================
+
+Unit tests that change global data should include the ``CleanUp`` base
+class, which provides simpler ``setUp`` and ``tearDown`` methods that call
+global-data cleanup routines.
+
+
+>>> def print_args(*args, **kw):
+...     print(args)
+...     print(kw)
+
+>>> from zope.testing.cleanup import addCleanUp, CleanUp
+>>> addCleanUp(print_args, ('1', 'foo'), {'bar': 42})
+
+``Cleanup`` calls the registered clean up functions on setup and tear down:
+
+>>> CleanUp().setUp()
+('1', 'foo')
+{'bar': 42}
+>>> CleanUp().tearDown()
+('1', 'foo')
+{'bar': 42}
+>>> CleanUp().cleanUp()
+('1', 'foo')
+{'bar': 42}

--- a/src/zope/testing/doctestcase.py
+++ b/src/zope/testing/doctestcase.py
@@ -22,7 +22,7 @@ You can define doctests in 4 ways:
 
    >>> __name__ = 'tests'
 
-Here are some examples::
+Here are some examples (they are tested via doctestcase.txt)::
 
     from zope.testing import doctestcase
     import doctest

--- a/src/zope/testing/doctestcase.txt
+++ b/src/zope/testing/doctestcase.txt
@@ -56,7 +56,17 @@ Here are some examples::
     ...     @doctestcase.doctestfile('test4.txt')
     ...     def test4(self):
     ...         self.x = 5
+    ...
 
+    >>> class MissingDocstring(unittest.TestCase):  #doctest: +ELLIPSIS
+    ...     """A doctest method has to have a docstring."""
+    ...
+    ...     @doctestcase.doctestmethod(optionflags=doctest.ELLIPSIS)
+    ...     def test55(self):
+    ...         pass
+    Traceback (most recent call last):
+    ...
+    ValueError: (<function ...test55 at 0x...>, 'has no docstring')
     >>> import sys
 
     >>> @doctestcase.doctestfiles('loggingsupport.txt', 'renormalizing.txt')

--- a/src/zope/testing/formparser.py
+++ b/src/zope/testing/formparser.py
@@ -13,6 +13,12 @@ __docformat__ = "reStructuredText"
 
 import HTMLParser
 import urlparse
+import warnings
+
+
+warnings.warn(
+    'zope.testing.formparser is deprecated. It does not work on Python 3.',
+    DeprecationWarning, stacklevel=2)
 
 
 def parse(data, base=None):

--- a/src/zope/testing/loghandler.py
+++ b/src/zope/testing/loghandler.py
@@ -14,6 +14,12 @@
 """logging handler for tests that check logging output.
 """
 import logging
+import warnings
+
+
+warnings.warn(
+    'zope.testing.loghandler.Handler is deprecated. It probably'
+    'does not work on Python 3.', DeprecationWarning, stacklevel=2)
 
 
 class Handler(logging.Handler):

--- a/src/zope/testing/loghandler.py
+++ b/src/zope/testing/loghandler.py
@@ -19,7 +19,7 @@ import warnings
 
 warnings.warn(
     'zope.testing.loghandler.Handler is deprecated. It probably'
-    'does not work on Python 3.', DeprecationWarning, stacklevel=2)
+    ' does not work on Python 3.', DeprecationWarning, stacklevel=2)
 
 
 class Handler(logging.Handler):

--- a/src/zope/testing/renormalizing.py
+++ b/src/zope/testing/renormalizing.py
@@ -62,7 +62,7 @@ class OutputChecker(doctest.OutputChecker):
         if doctest.OutputChecker.check_output(self, want, got, optionflags):
             return True
 
-        if sys.version_info[0] < 3:
+        if sys.version_info[0] < 3:  # pragma: PY2
             if optionflags & IGNORE_EXCEPTION_MODULE_IN_PYTHON2:
                 want = strip_dottedname_from_traceback(want)
                 if doctest.OutputChecker.check_output(
@@ -93,7 +93,7 @@ class OutputChecker(doctest.OutputChecker):
         # temporarily hack example with normalized want:
         example.want = want
 
-        if sys.version_info[0] < 3:
+        if sys.version_info[0] < 3:  # pragma: PY2
             if optionflags & IGNORE_EXCEPTION_MODULE_IN_PYTHON2:
                 if maybe_a_traceback(got) is not None:
                     got += IGNORE_EXCEPTION_MODULE_IN_PYTHON2_HINT
@@ -109,11 +109,11 @@ RENormalizing = OutputChecker
 
 
 def is_dotted_name(name):
-    if sys.version_info[0] >= 3:
+    if sys.version_info[0] >= 3:  # pragma: PY3
         return (
             name and
             all(element.isidentifier() for element in name.split('.')))
-    else:
+    else:  # pragma: PY2
         # Python 2 lacked str.isidentifier, but also restricted identifiers
         # to ASCII so a regex match is straightforward.
         match = re.match(

--- a/src/zope/testing/server.py
+++ b/src/zope/testing/server.py
@@ -25,13 +25,23 @@ functional test.
 from __future__ import print_function
 
 import sys
+import warnings
 import webbrowser
-import urlparse
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 # XXX: I don't think this module works on Python 3!
 
+try:  # pragma: PY3
+    from urllib import parse as urlparse
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+except ImportError:  # pragma: PY2
+    import urlparse
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
-def makeRequestHandler(http, user=None, password=None):
+
+def makeRequestHandler(http, user=None, password=None):  # pragma: PY2
+    warnings.warn(
+        'zope.testing.server.makeRequestHandler is deprecated. It probably'
+        'does not work on Python 3.', DeprecationWarning, stacklevel=2)
+
     class FunctionalTestRequestHandler(BaseHTTPRequestHandler):
 
         def do_GET(self):
@@ -88,7 +98,10 @@ def addPortToURL(url, port):
     return url
 
 
-def startServer(http, url, user=None, password=None, port=8000):
+def startServer(http, url, user=None, password=None, port=8000):  # pragma: PY2
+    warnings.warn(
+        'zope.testing.server.startServer is deprecated. It probably'
+        'does not work on Python 3.', DeprecationWarning, stacklevel=2)
     try:
         server_address = ('', port)
         requestHandler = makeRequestHandler(http, user, password)

--- a/src/zope/testing/server.py
+++ b/src/zope/testing/server.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: PY2
 def makeRequestHandler(http, user=None, password=None):  # pragma: PY2
     warnings.warn(
         'zope.testing.server.makeRequestHandler is deprecated. It probably'
-        'does not work on Python 3.', DeprecationWarning, stacklevel=2)
+        ' does not work on Python 3.', DeprecationWarning, stacklevel=2)
 
     class FunctionalTestRequestHandler(BaseHTTPRequestHandler):
 
@@ -101,7 +101,7 @@ def addPortToURL(url, port):
 def startServer(http, url, user=None, password=None, port=8000):  # pragma: PY2
     warnings.warn(
         'zope.testing.server.startServer is deprecated. It probably'
-        'does not work on Python 3.', DeprecationWarning, stacklevel=2)
+        ' does not work on Python 3.', DeprecationWarning, stacklevel=2)
     try:
         server_address = ('', port)
         requestHandler = makeRequestHandler(http, user, password)

--- a/src/zope/testing/setupstack.txt
+++ b/src/zope/testing/setupstack.txt
@@ -228,6 +228,7 @@ Here's an example:
     ...
     ...     def setUp(self):
     ...         self.setUpDirectory()
+    ...         os.mkdir('example')
     ...         self.context_manager(manager)
     ...         self.mock("time.time", return_value=42)
     ...

--- a/src/zope/testing/setupstack.txt
+++ b/src/zope/testing/setupstack.txt
@@ -228,6 +228,8 @@ Here's an example:
     ...
     ...     def setUp(self):
     ...         self.setUpDirectory()
+    ...         # Create a new directory in the one set up above, which gets
+    ...         # deleted in tear down:
     ...         os.mkdir('example')
     ...         self.context_manager(manager)
     ...         self.mock("time.time", return_value=42)

--- a/src/zope/testing/test_renormalizing.py
+++ b/src/zope/testing/test_renormalizing.py
@@ -18,16 +18,16 @@ class Exception2To3(unittest.TestCase):
 
     def test_is_dotted_name_unicode_no_dots(self):
         result = is_dotted_name(u'FooB\xe1rError')
-        if sys.version_info[0] >= 3:
+        if sys.version_info[0] >= 3:  # pragma: PY3
             self.assertTrue(result)
-        else:
+        else:  # pragma: PY2
             self.assertFalse(result)
 
     def test_is_dotted_name_unicode_dots(self):
         result = is_dotted_name(u'foo.b\xe1r.FooB\xe1rError')
-        if sys.version_info[0] >= 3:
+        if sys.version_info[0] >= 3:  # pragma: PY3
             self.assertTrue(result)
-        else:
+        else:  # pragma: PY2
             self.assertFalse(result)
 
     def test_is_dotted_name_ellipsis(self):

--- a/src/zope/testing/tests.py
+++ b/src/zope/testing/tests.py
@@ -53,15 +53,14 @@ def test_suite():
                 # For Python 3.5
                 (re.compile('zope.testing.wait.Wait.TimeOutWaitingFor: '),
                  'TimeOutWaitingFor: '),
-                ])
-            ),
-        ))
+            ])
+        ),
+    ))
 
-    if sys.version_info[:2] >= (2, 7):
-        suite.addTests(doctest.DocFileSuite('doctestcase.txt'))
-    if sys.version_info[0] < 3:
-        suite.addTests(doctest.DocTestSuite('zope.testing.server'))
+    suite.addTests(doctest.DocFileSuite('doctestcase.txt'))
+    suite.addTests(doctest.DocFileSuite('cleanup.txt'))
+    suite.addTest(unittest.makeSuite(Exception2To3))
+    suite.addTests(doctest.DocTestSuite('zope.testing.server'))
+    if sys.version_info[0] < 3:  # pragma: PY2
         suite.addTests(doctest.DocFileSuite('formparser.txt'))
-    suite.addTest(
-        unittest.makeSuite(Exception2To3))
     return suite

--- a/tox.ini
+++ b/tox.ini
@@ -45,12 +45,18 @@ commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
     coverage html
-    coverage report -m --fail-under=55
+    coverage report -m --fail-under=99
 
 [coverage:run]
 branch = True
 plugins = coverage_python_version
 source = zope.testing
+# omit files which just contain BBB code or are not Python 3 compatible:
+omit =
+    src/zope/testing/exceptions.py
+    src/zope/testing/formparser.py
+    src/zope/testing/loghandler.py
+    src/zope/testing/testrunner.py
 
 [coverage:report]
 precision = 2


### PR DESCRIPTION
Show deprecation warnings when importing modules which are not ported to Python 3.

Fixes #36.