### PR TITLE
Remove obsolete `setuptools` runtime dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Remove unnecessary ``setuptools`` runtime dependency.
 
 
 6.0 (2025-09-12)

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,6 @@ setup(
     ],
     keywords=keywords,
     python_requires='>=3.9',
-    install_requires=[
-        'setuptools',
-    ],
     extras_require={
         'test': [
             'zope.testrunner >= 6.4',


### PR DESCRIPTION
The runtime dependency on `setuptools` was only required for namespace support.  Since `pkg_resources`-style namespaces have been removed in #52 and there are no relevant imports left in the code, remove the unnecessary dependency.

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.